### PR TITLE
fix entities path

### DIFF
--- a/output-api/src/services/database.config.service.ts
+++ b/output-api/src/services/database.config.service.ts
@@ -21,7 +21,7 @@ export class DatabaseConfigService implements TypeOrmOptionsFactory {
             synchronize: true,
             logging: false,
             entities: [
-                "dist/output-api/src/entity/**/*.js"
+                "dist/output-api/src/entity/*.ts"
             ],
             migrations: [
                 "dist/output-api/src/migration/**/*.js"


### PR DESCRIPTION
* Changes to the database schema were not applied at the start of the backend because the path for the entities was incorrect
* This meant that rest endpoint like the optional_fields were not created