### PR TITLE
Add Jest tooling to output API project

### DIFF
--- a/output-api/jest.config.ts
+++ b/output-api/jest.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1',
+  },
+  testRegex: '.*\\.spec\\.ts$',
+  collectCoverageFrom: ['src/**/*.service.ts', 'src/**/*.controller.ts'],
+  coverageDirectory: 'coverage',
+  transform: {
+    '^.+\\.(t|j)s$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.spec.json',
+      },
+    ],
+  },
+};
+
+export default config;

--- a/output-api/package.json
+++ b/output-api/package.json
@@ -3,12 +3,16 @@
    "version": "1.0.0-beta",
    "description": "Publication management for universities.",
    "devDependencies": {
+      "@nestjs/testing": "^10.4.4",
       "@types/cookie-parser": "^1.4.7",
+      "@types/jest": "^29.5.12",
       "@types/multer": "^1.4.12",
       "@types/node": "^22.7.5",
+      "jest": "^29.7.0",
+      "rimraf": "^6.0.1",
+      "ts-jest": "^29.2.5",
       "ts-node": "^10.9.2",
-      "typescript": "^5.6.3",
-      "rimraf": "^6.0.1"
+      "typescript": "^5.6.3"
    },
    "dependencies": {
       "@nestjs/axios": "3.0.3",

--- a/output-api/tsconfig.spec.json
+++ b/output-api/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add Jest, ts-jest, and supporting @types and Nest testing utilities as dev dependencies
- create a ts-jest configuration that maps src paths and collects coverage from controllers and services
- add a Jest-specific tsconfig that enables the Jest type definitions

## Testing
- npm test *(fails: local environment could not download @nestjs/testing, leaving jest unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5839d0f0833080f419a4b73a91a9