### PR TITLE
Strengthen merge combine specs with data aggregation assertions

### DIFF
--- a/output-api/src/contract/contract.service.spec.ts
+++ b/output-api/src/contract/contract.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ContractService } from './contract.service';
+import { Contract } from './Contract';
+import { ContractIdentifier } from './ContractIdentifier';
+import { PublicationService } from '../publication/core/publication.service';
+import { AppConfigService } from '../config/app-config.service';
+describe('ContractService', () => {
+    let service: ContractService;
+    let repository: jest.Mocked<Partial<Repository<Contract>>>;
+    let identifierRepository: jest.Mocked<Partial<Repository<ContractIdentifier>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        identifierRepository = {
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ContractService,
+                { provide: getRepositoryToken(Contract), useValue: repository },
+                { provide: getRepositoryToken(ContractIdentifier), useValue: identifierRepository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(ContractService);
+    });
+
+    it('merges contracts by concatenating identifiers and reassigning publications', async () => {
+        const primary: Contract = {
+            id: 11,
+            label: 'Primary Contract',
+            start_date: new Date('2020-01-01'),
+            invoice_amount: null,
+            publisher: null,
+            publications: [{ id: 30 }] as any,
+            identifiers: [{ id: 1, value: 'ABC', type: 'internal', entity: { id: 11 } }] as any,
+        } as Contract;
+        const duplicateA: Contract = {
+            id: 12,
+            label: 'Duplicate A',
+            invoice_amount: 100,
+            publisher: { id: 2, label: 'Publisher' } as any,
+            publications: [{ id: 31, contract: { id: 12 } }] as any,
+            identifiers: [{ id: 2, value: 'DEF', type: 'external', entity: { id: 12 } }] as any,
+        } as Contract;
+        const duplicateB: Contract = {
+            id: 13,
+            label: 'Duplicate B',
+            invoice_amount: 200,
+            publisher: null,
+            publications: [{ id: 32, contract: { id: 13 } }] as any,
+            identifiers: [],
+        } as Contract;
+
+        const byId = new Map<number, Contract>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as Contract);
+        repository.delete!.mockResolvedValue(undefined as never);
+        publicationService.save.mockResolvedValue(undefined);
+        identifierRepository.delete!.mockResolvedValue(undefined as never);
+
+        const combined = await service.combine(11, [12, 13], ['alias']);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 11,
+            label: 'Primary Contract',
+            start_date: new Date('2020-01-01'),
+            invoice_amount: 100,
+            publisher: expect.objectContaining({ id: 2 }),
+            identifiers: expect.arrayContaining([
+                expect.objectContaining({ value: 'ABC' }),
+                expect.objectContaining({ value: 'DEF' }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ invoice_amount: 100 }));
+        expect(publicationService.save).toHaveBeenCalledTimes(2);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 31, contract: expect.objectContaining({ id: 11 }) }),
+        ]);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 32, contract: expect.objectContaining({ id: 11 }) }),
+        ]);
+        expect(identifierRepository.delete).toHaveBeenCalled();
+        expect(repository.delete).toHaveBeenCalledWith([12, 13]);
+    });
+});

--- a/output-api/src/funder/funder.service.spec.ts
+++ b/output-api/src/funder/funder.service.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { FunderService } from './funder.service';
+import { Funder } from './Funder';
+import { AliasFunder } from './AliasFunder';
+import { PublicationService } from '../publication/core/publication.service';
+import { AliasLookupService } from '../common/alias-lookup.service';
+import { AppConfigService } from '../config/app-config.service';
+describe('FunderService', () => {
+    let service: FunderService;
+    let repository: jest.Mocked<Partial<Repository<Funder>>>;
+    let aliasRepository: jest.Mocked<Partial<Repository<AliasFunder>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        aliasRepository = {
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FunderService,
+                { provide: getRepositoryToken(Funder), useValue: repository },
+                { provide: getRepositoryToken(AliasFunder), useValue: aliasRepository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AliasLookupService, useValue: { findCanonicalElement: jest.fn() } },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(FunderService);
+    });
+
+    it('combines funders by aggregating aliases and reassigning funding relationships', async () => {
+        const primary: Funder = {
+            id: 21,
+            label: 'Primary Funder',
+            doi: null,
+            aliases: [{ id: 1, alias: 'primary', elementId: 21 } as any],
+            publications: [{ id: 40 }] as any,
+        } as Funder;
+        const duplicate: Funder = {
+            id: 22,
+            label: 'Duplicate Funder',
+            doi: '10.1234/dup',
+            aliases: [{ id: 2, alias: 'dup', elementId: 22 } as any],
+            publications: [{
+                id: 41,
+                funders: [
+                    { id: 22, label: 'Duplicate Funder' },
+                    { id: 99, label: 'Other' },
+                ],
+            }] as any,
+        } as Funder;
+
+        const byId = new Map<number, Funder>([
+            [primary.id, primary],
+            [duplicate.id, duplicate],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as Funder);
+        repository.delete!.mockResolvedValue(undefined as never);
+        aliasRepository.delete!.mockResolvedValue(undefined as never);
+        publicationService.save.mockResolvedValue(undefined);
+
+        const combined = await service.combine(21, [22], ['new-alias']);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 21,
+            label: 'Primary Funder',
+            doi: '10.1234/dup',
+            aliases: expect.arrayContaining([
+                expect.objectContaining({ alias: 'primary' }),
+                expect.objectContaining({ alias: 'dup' }),
+                expect.objectContaining({ alias: 'new-alias', elementId: 21 }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ doi: '10.1234/dup' }));
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({
+                id: 41,
+                funders: expect.arrayContaining([
+                    expect.objectContaining({ id: 21 }),
+                    expect.objectContaining({ id: 99 }),
+                ]),
+            }),
+        ]);
+        expect(aliasRepository.delete).toHaveBeenCalled();
+        expect(repository.delete).toHaveBeenCalledWith([22]);
+    });
+});

--- a/output-api/src/greater_entity/greater-entitiy.service.spec.ts
+++ b/output-api/src/greater_entity/greater-entitiy.service.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { GreaterEntityService } from './greater-entitiy.service';
+import { GreaterEntity } from './GreaterEntity';
+import { GEIdentifier } from './GEIdentifier';
+import { PublicationService } from '../publication/core/publication.service';
+import { AppConfigService } from '../config/app-config.service';
+describe('GreaterEntityService', () => {
+    let service: GreaterEntityService;
+    let repository: jest.Mocked<Partial<Repository<GreaterEntity>>>;
+    let identifierRepository: jest.Mocked<Partial<Repository<GEIdentifier>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        identifierRepository = {
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                GreaterEntityService,
+                { provide: getRepositoryToken(GreaterEntity), useValue: repository },
+                { provide: getRepositoryToken(GEIdentifier), useValue: identifierRepository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(GreaterEntityService);
+    });
+
+    it('combines greater entities by merging identifiers and unifying publication links', async () => {
+        const primary: GreaterEntity = {
+            id: 41,
+            label: 'Primary GE',
+            rating: 'A',
+            doaj_since: null,
+            doaj_until: null,
+            identifiers: [{ id: 1, value: 'ID-A', type: 'type-a', entity: { id: 41 } }] as any,
+            publications: [{ id: 50 }] as any,
+        } as GreaterEntity;
+        const duplicateA: GreaterEntity = {
+            id: 42,
+            label: 'Duplicate A',
+            doaj_since: new Date('2021-01-01'),
+            doaj_until: new Date('2022-01-01'),
+            identifiers: [{ id: 2, value: 'ID-B', type: 'type-b', entity: { id: 42 } }] as any,
+            publications: [{ id: 51, greater_entity: { id: 42 } }] as any,
+        } as GreaterEntity;
+        const duplicateB: GreaterEntity = {
+            id: 43,
+            label: 'Duplicate B',
+            doaj_since: null,
+            doaj_until: null,
+            identifiers: [{ id: 3, value: 'ID-C', type: 'type-c', entity: { id: 43 } }] as any,
+            publications: [{ id: 52, greater_entity: { id: 43 } }] as any,
+        } as GreaterEntity;
+
+        const byId = new Map<number, GreaterEntity>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as GreaterEntity);
+        repository.delete!.mockResolvedValue(undefined as never);
+        identifierRepository.delete!.mockResolvedValue(undefined as never);
+        publicationService.save.mockResolvedValue(undefined);
+
+        const combined = await service.combine(41, [42, 43]);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 41,
+            label: 'Primary GE',
+            doaj_since: new Date('2021-01-01'),
+            doaj_until: new Date('2022-01-01'),
+            identifiers: expect.arrayContaining([
+                expect.objectContaining({ value: 'ID-A' }),
+                expect.objectContaining({ value: 'ID-B' }),
+                expect.objectContaining({ value: 'ID-C' }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ doaj_since: new Date('2021-01-01') }));
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 51, greater_entity: expect.objectContaining({ id: 41 }) }),
+        ]);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 52, greater_entity: expect.objectContaining({ id: 41 }) }),
+        ]);
+        expect(identifierRepository.delete).toHaveBeenCalled();
+        expect(repository.delete).toHaveBeenCalledWith([42, 43]);
+    });
+});

--- a/output-api/src/institute/institute.service.spec.ts
+++ b/output-api/src/institute/institute.service.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+
+import { InstituteService } from './institute.service';
+import { Institute } from './Institute';
+import { AuthorPublication } from '../publication/relations/AuthorPublication';
+import { Author } from '../author/Author';
+import { AliasInstitute } from './AliasInstitute';
+import { AppConfigService } from '../config/app-config.service';
+import { AliasLookupService } from '../common/alias-lookup.service';
+describe('InstituteService', () => {
+    let service: InstituteService;
+    let repository: jest.Mocked<Partial<Repository<Institute>>>;
+    let manager: { getTreeRepository: jest.Mock };
+    let pubAutRepository: jest.Mocked<Partial<Repository<AuthorPublication>>>;
+    let authorRepository: jest.Mocked<Partial<Repository<Author>>>;
+    let aliasRepository: jest.Mocked<Partial<Repository<AliasInstitute>>>;
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        manager = {
+            getTreeRepository: jest.fn().mockReturnValue(repository),
+        };
+        pubAutRepository = {
+            save: jest.fn(),
+        };
+        authorRepository = {
+            save: jest.fn(),
+        };
+        aliasRepository = {
+            delete: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                InstituteService,
+                { provide: EntityManager, useValue: manager },
+                { provide: getRepositoryToken(AuthorPublication), useValue: pubAutRepository },
+                { provide: getRepositoryToken(Author), useValue: authorRepository },
+                { provide: getRepositoryToken(AliasInstitute), useValue: aliasRepository },
+                { provide: AliasLookupService, useValue: { findCanonicalElement: jest.fn() } },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(InstituteService);
+    });
+
+    it('combines institutes by merging hierarchy metadata and updating author affiliations', async () => {
+        expect(manager.getTreeRepository).toHaveBeenCalledWith(Institute);
+
+        const primary: Institute = {
+            id: 31,
+            label: 'Primary Institute',
+            short_label: 'Primary',
+            aliases: [{ id: 1, alias: 'existing', elementId: 31 } as any],
+            super_institute: null,
+            authors: [{ id: 501, institutes: [{ id: 31 }] as any[] } as any],
+            authorPublications: [],
+        } as Institute;
+        const duplicateA: Institute = {
+            id: 32,
+            label: 'Duplicate A',
+            short_label: 'Dup A',
+            aliases: [{ id: 2, alias: 'dup', elementId: 32 } as any],
+            super_institute: { id: 100, label: 'Parent' } as any,
+            authors: [{ id: 502, institutes: [{ id: 32 }] as any[] } as any],
+            authorPublications: [{ id: 601, institute: { id: 32 } }] as any,
+        } as Institute;
+        const duplicateB: Institute = {
+            id: 33,
+            label: 'Duplicate B',
+            aliases: [],
+            super_institute: null,
+            authors: [],
+            authorPublications: [],
+        } as Institute;
+
+        const byId = new Map<number, Institute>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as Institute);
+        repository.delete!.mockResolvedValue(undefined as never);
+        pubAutRepository.save!.mockResolvedValue(undefined as never);
+        authorRepository.save!.mockResolvedValue(undefined as never);
+
+        const combined = await service.combine(31, [32, 33], ['alias-one']);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 31,
+            label: 'Primary Institute',
+            super_institute: expect.objectContaining({ id: 100 }),
+            aliases: expect.arrayContaining([
+                expect.objectContaining({ alias: 'existing' }),
+                expect.objectContaining({ alias: 'dup' }),
+                expect.objectContaining({ alias: 'alias-one', elementId: 31 }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ super_institute: expect.objectContaining({ id: 100 }) }));
+        expect(pubAutRepository.save).toHaveBeenCalledWith({ id: 601, institute: expect.objectContaining({ id: 31 }) });
+        expect(authorRepository.save).toHaveBeenCalledWith({
+            id: 502,
+            institutes: expect.arrayContaining([
+                expect.objectContaining({ id: 31 }),
+            ]),
+        });
+        expect(repository.delete).toHaveBeenCalledWith([32, 33]);
+    });
+});

--- a/output-api/src/oa_category/oa-category.service.spec.ts
+++ b/output-api/src/oa_category/oa-category.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { OACategoryService } from './oa-category.service';
+import { OA_Category } from './OA_Category';
+import { PublicationService } from '../publication/core/publication.service';
+import { AppConfigService } from '../config/app-config.service';
+describe('OACategoryService', () => {
+    let service: OACategoryService;
+    let repository: jest.Mocked<Partial<Repository<OA_Category>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                OACategoryService,
+                { provide: getRepositoryToken(OA_Category), useValue: repository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(OACategoryService);
+    });
+
+    it('combines duplicate OA categories by preserving the primary label and enriching missing metadata', async () => {
+        const primary: OA_Category = {
+            id: 10,
+            label: 'Primary Label',
+            description: null,
+            is_oa: true,
+            publications: [{ id: 1 }] as any,
+        } as OA_Category;
+        const duplicateA: OA_Category = {
+            id: 20,
+            label: 'Duplicate A',
+            description: 'Description from duplicate',
+            is_oa: false,
+            publications: [{ id: 2, oa_category: { id: 20 } }] as any,
+        } as OA_Category;
+        const duplicateB: OA_Category = {
+            id: 30,
+            label: 'Duplicate B',
+            description: null,
+            is_oa: true,
+            publications: [{ id: 3, oa_category: { id: 30 } }] as any,
+        } as OA_Category;
+
+        const byId = new Map<number, OA_Category>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as OA_Category);
+        publicationService.save.mockResolvedValue(undefined);
+        repository.delete!.mockResolvedValue(undefined as never);
+
+        const combined = await service.combine(10, [20, 30]);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 10,
+            label: 'Primary Label',
+            description: 'Description from duplicate',
+            is_oa: true,
+        }));
+        expect(combined).toEqual(expect.objectContaining({
+            id: 10,
+            description: 'Description from duplicate',
+        }));
+        expect(publicationService.save).toHaveBeenCalledTimes(2);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 2, oa_category: expect.objectContaining({ id: 10 }) }),
+        ]);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 3, oa_category: expect.objectContaining({ id: 10 }) }),
+        ]);
+        expect(repository.delete).toHaveBeenCalledWith([20, 30]);
+    });
+});

--- a/output-api/src/pub_type/publication-type.service.spec.ts
+++ b/output-api/src/pub_type/publication-type.service.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { PublicationTypeService } from './publication-type.service';
+import { PublicationType } from './PublicationType';
+import { AliasPubType } from './AliasPubType';
+import { PublicationService } from '../publication/core/publication.service';
+import { AppConfigService } from '../config/app-config.service';
+describe('PublicationTypeService', () => {
+    let service: PublicationTypeService;
+    let repository: jest.Mocked<Partial<Repository<PublicationType>>>;
+    let aliasRepository: jest.Mocked<Partial<Repository<AliasPubType>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        aliasRepository = {
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PublicationTypeService,
+                { provide: getRepositoryToken(PublicationType), useValue: repository },
+                { provide: getRepositoryToken(AliasPubType), useValue: aliasRepository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(PublicationTypeService);
+    });
+
+    it('combines publication types by merging aliases and preserving the primary label', async () => {
+        const primary: PublicationType = {
+            id: 4,
+            label: 'Primary Type',
+            review: null,
+            aliases: [{ id: 1, alias: 'existing', elementId: 4 } as any],
+            publications: [{ id: 2 }] as any,
+        } as PublicationType;
+        const duplicateA: PublicationType = {
+            id: 7,
+            label: 'Duplicate A',
+            review: true,
+            aliases: [{ id: 3, alias: 'dup-a', elementId: 7 } as any],
+            publications: [{ id: 5, pub_type: { id: 7 } }] as any,
+        } as PublicationType;
+        const duplicateB: PublicationType = {
+            id: 8,
+            label: 'Duplicate B',
+            review: false,
+            aliases: [],
+            publications: [{ id: 6, pub_type: { id: 8 } }] as any,
+        } as PublicationType;
+
+        const byId = new Map<number, PublicationType>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as PublicationType);
+        repository.delete!.mockResolvedValue(undefined as never);
+        publicationService.save.mockResolvedValue(undefined);
+        aliasRepository.delete!.mockResolvedValue(undefined as never);
+
+        const combined = await service.combine(4, [7, 8], ['new-alias']);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 4,
+            label: 'Primary Type',
+            review: true,
+            aliases: expect.arrayContaining([
+                expect.objectContaining({ alias: 'existing' }),
+                expect.objectContaining({ alias: 'dup-a' }),
+                expect.objectContaining({ alias: 'new-alias', elementId: 4 }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ review: true }));
+        expect(publicationService.save).toHaveBeenCalledTimes(2);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 5, pub_type: expect.objectContaining({ id: 4 }) }),
+        ]);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 6, pub_type: expect.objectContaining({ id: 4 }) }),
+        ]);
+        expect(aliasRepository.delete).toHaveBeenCalledWith({ elementId: expect.anything() });
+        expect(repository.delete).toHaveBeenCalledWith([7, 8]);
+    });
+});

--- a/output-api/src/publication/core/publication.service.spec.ts
+++ b/output-api/src/publication/core/publication.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { PublicationService } from './publication.service';
+import { Publication } from './Publication';
+import { AuthorPublication } from '../relations/AuthorPublication';
+import { Invoice } from '../../invoice/Invoice';
+import { CostItem } from '../../invoice/CostItem';
+import { PublicationIdentifier } from './PublicationIdentifier';
+import { PublicationSupplement } from './PublicationSupplement';
+import { PublicationDuplicate } from './PublicationDuplicate';
+import { AppConfigService } from '../../config/app-config.service';
+import { InstituteService } from '../../institute/institute.service';
+describe('PublicationService combine', () => {
+    let service: PublicationService;
+    let pubRepository: jest.Mocked<Partial<Repository<Publication>>>;
+    let pubAutRepository: jest.Mocked<Partial<Repository<AuthorPublication>>>;
+    let invoiceRepository: jest.Mocked<Partial<Repository<Invoice>>>;
+    let costItemRepository: jest.Mocked<Partial<Repository<CostItem>>>;
+    let idRepository: jest.Mocked<Partial<Repository<PublicationIdentifier>>>;
+    let supplRepository: jest.Mocked<Partial<Repository<PublicationSupplement>>>;
+    let duplRepository: jest.Mocked<Partial<Repository<PublicationDuplicate>>>;
+    beforeEach(async () => {
+        pubRepository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        pubAutRepository = {
+            delete: jest.fn(),
+            save: jest.fn(),
+        };
+        invoiceRepository = {
+            delete: jest.fn(),
+        };
+        costItemRepository = {
+            delete: jest.fn(),
+        };
+        idRepository = {
+            save: jest.fn(),
+        };
+        supplRepository = {
+            delete: jest.fn(),
+        };
+        duplRepository = {
+            find: jest.fn(),
+            delete: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PublicationService,
+                { provide: getRepositoryToken(Publication), useValue: pubRepository },
+                { provide: getRepositoryToken(AuthorPublication), useValue: pubAutRepository },
+                { provide: getRepositoryToken(Invoice), useValue: invoiceRepository },
+                { provide: getRepositoryToken(CostItem), useValue: costItemRepository },
+                { provide: getRepositoryToken(PublicationIdentifier), useValue: idRepository },
+                { provide: getRepositoryToken(PublicationSupplement), useValue: supplRepository },
+                { provide: getRepositoryToken(PublicationDuplicate), useValue: duplRepository },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+                { provide: InstituteService, useValue: { findOrSave: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(PublicationService);
+    });
+
+    it('combines publications by preserving locked state and aggregating related records', async () => {
+        const duplicateForward = [{ id: 501 } as PublicationDuplicate];
+        const duplicateReverse = [{ id: 502 } as PublicationDuplicate];
+        duplRepository.find
+            .mockResolvedValueOnce(duplicateForward)
+            .mockResolvedValueOnce(duplicateReverse);
+
+        const primary: Publication = {
+            id: 61,
+            locked: false,
+            title: 'Primary Publication',
+            doi: '10.primary/doi',
+            greater_entity: null,
+            funders: [{ id: 201 } as any],
+            identifiers: [{ id: 1, value: 'ID-1', type: 'doi', entity: { id: 61 } }] as any,
+            supplements: [{ id: 701 }] as any,
+            authorPublications: [{ id: 801, institute: { id: 10 } }] as any,
+        } as Publication;
+        const duplicateA: Publication = {
+            id: 62,
+            locked: false,
+            title: 'Duplicate A',
+            doi: null,
+            greater_entity: { id: 300, label: 'GE' } as any,
+            funders: [{ id: 202 } as any],
+            identifiers: [{ id: 2, value: 'ID-2', type: 'isbn', entity: { id: 62 } }] as any,
+            supplements: [{ id: 702 }] as any,
+            authorPublications: [{ id: 802, institute: { id: 12 } }] as any,
+        } as Publication;
+        const duplicateB: Publication = {
+            id: 63,
+            locked: false,
+            title: 'Duplicate B',
+            doi: '10.duplicate/doi',
+            greater_entity: null,
+            funders: [{ id: 203 } as any],
+            identifiers: [],
+            supplements: [],
+            authorPublications: [],
+        } as Publication;
+
+        const byId = new Map<number, Publication>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        pubRepository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        pubRepository.save.mockImplementation(async entity => entity as Publication);
+        pubRepository.delete!.mockResolvedValue(undefined as never);
+        pubAutRepository.delete!.mockResolvedValue(undefined as never);
+        pubAutRepository.save!.mockResolvedValue(undefined as never);
+        invoiceRepository.delete!.mockResolvedValue(undefined as never);
+        supplRepository.delete!.mockResolvedValue(undefined as never);
+        duplRepository.delete!.mockResolvedValue(undefined as never);
+
+        const combined = await service.combine(61, [62, 63], ['alias-a']);
+
+        expect(duplRepository.find).toHaveBeenCalledTimes(2);
+        expect(pubRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 61,
+            doi: '10.primary/doi',
+            greater_entity: expect.objectContaining({ id: 300 }),
+            funders: expect.arrayContaining([
+                expect.objectContaining({ id: 201 }),
+                expect.objectContaining({ id: 202 }),
+                expect.objectContaining({ id: 203 }),
+            ]),
+            identifiers: expect.arrayContaining([
+                expect.objectContaining({ value: 'ID-1' }),
+                expect.objectContaining({ value: 'ID-2' }),
+            ]),
+            supplements: expect.arrayContaining([
+                expect.objectContaining({ id: 701 }),
+                expect.objectContaining({ id: 702 }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({
+            id: 61,
+            greater_entity: expect.objectContaining({ id: 300 }),
+            funders: expect.arrayContaining([
+                expect.objectContaining({ id: 201 }),
+                expect.objectContaining({ id: 202 }),
+                expect.objectContaining({ id: 203 }),
+            ]),
+        }));
+        expect(pubAutRepository.save).toHaveBeenCalledWith({
+            id: 802,
+            publication: expect.objectContaining({ id: 61 }),
+        });
+        expect(pubAutRepository.delete).toHaveBeenCalledWith({ publicationId: expect.anything() });
+        expect(invoiceRepository.delete).toHaveBeenCalledWith({ publication: { id: expect.anything() } });
+        expect(supplRepository.delete).toHaveBeenCalledWith({ publication: { id: expect.anything() } });
+        expect(duplRepository.delete).toHaveBeenCalledWith([501, 502]);
+        expect(pubRepository.delete).toHaveBeenCalledWith([62, 63]);
+    });
+});

--- a/output-api/src/publisher/publisher.service.spec.ts
+++ b/output-api/src/publisher/publisher.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { PublisherService } from './publisher.service';
+import { Publisher } from './Publisher';
+import { AliasPublisher } from './AliasPublisher';
+import { PublisherDOI } from './PublisherDOI';
+import { PublicationService } from '../publication/core/publication.service';
+import { AppConfigService } from '../config/app-config.service';
+import { AliasLookupService } from '../common/alias-lookup.service';
+describe('PublisherService', () => {
+    let service: PublisherService;
+    let repository: jest.Mocked<Partial<Repository<Publisher>>>;
+    let aliasRepository: jest.Mocked<Partial<Repository<AliasPublisher>>>;
+    let doiRepository: jest.Mocked<Partial<Repository<PublisherDOI>>>;
+    let publicationService: { save: jest.Mock };
+
+    beforeEach(async () => {
+        repository = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+        };
+        aliasRepository = {
+            delete: jest.fn(),
+        };
+        doiRepository = {
+            delete: jest.fn(),
+        };
+        publicationService = {
+            save: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PublisherService,
+                { provide: getRepositoryToken(Publisher), useValue: repository },
+                { provide: getRepositoryToken(AliasPublisher), useValue: aliasRepository },
+                { provide: getRepositoryToken(PublisherDOI), useValue: doiRepository },
+                { provide: PublicationService, useValue: publicationService },
+                { provide: AliasLookupService, useValue: { findCanonicalElement: jest.fn() } },
+                { provide: AppConfigService, useValue: { get: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(PublisherService);
+    });
+
+    it('merges publisher data by combining aliases and DOI prefixes without losing the primary identity', async () => {
+        const primary: Publisher = {
+            id: 5,
+            label: 'Primary Publisher',
+            doi_prefixes: [{ id: 1, doi_prefix: '10.1000', publisherId: 5 } as any],
+            aliases: [{ id: 1, alias: 'primary', elementId: 5 } as any],
+            publications: [{ id: 21 }] as any,
+        } as Publisher;
+        const duplicateA: Publisher = {
+            id: 9,
+            label: 'Duplicate A',
+            doi_prefixes: [{ id: 2, doi_prefix: '10.2000', publisherId: 9 } as any],
+            aliases: [{ id: 3, alias: 'dup-a', elementId: 9 } as any],
+            publications: [{ id: 22, publisher: { id: 9 } }] as any,
+        } as Publisher;
+        const duplicateB: Publisher = {
+            id: 10,
+            label: 'Duplicate B',
+            doi_prefixes: [],
+            aliases: [],
+            publications: [{ id: 23, publisher: { id: 10 } }] as any,
+        } as Publisher;
+
+        const byId = new Map<number, Publisher>([
+            [primary.id, primary],
+            [duplicateA.id, duplicateA],
+            [duplicateB.id, duplicateB],
+        ]);
+
+        repository.findOne.mockImplementation(async ({ where }: any) => byId.get(where.id));
+        repository.save.mockImplementation(async entity => entity as Publisher);
+        repository.delete!.mockResolvedValue(undefined as never);
+        aliasRepository.delete!.mockResolvedValue(undefined as never);
+        doiRepository.delete!.mockResolvedValue(undefined as never);
+        publicationService.save.mockResolvedValue(undefined);
+
+        const combined = await service.combine(5, [9, 10], ['new-alias']);
+
+        expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({
+            id: 5,
+            label: 'Primary Publisher',
+            aliases: expect.arrayContaining([
+                expect.objectContaining({ alias: 'primary' }),
+                expect.objectContaining({ alias: 'dup-a' }),
+                expect.objectContaining({ alias: 'new-alias', elementId: 5 }),
+            ]),
+            doi_prefixes: expect.arrayContaining([
+                expect.objectContaining({ doi_prefix: '10.1000' }),
+                expect.objectContaining({ doi_prefix: '10.2000' }),
+            ]),
+        }));
+        expect(combined).toEqual(expect.objectContaining({ label: 'Primary Publisher' }));
+        expect(publicationService.save).toHaveBeenCalledTimes(2);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 22, publisher: expect.objectContaining({ id: 5 }) }),
+        ]);
+        expect(publicationService.save).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 23, publisher: expect.objectContaining({ id: 5 }) }),
+        ]);
+        expect(aliasRepository.delete).toHaveBeenCalled();
+        expect(doiRepository.delete).toHaveBeenCalled();
+        expect(repository.delete).toHaveBeenCalledWith([9, 10]);
+    });
+});


### PR DESCRIPTION
## Summary
- replace mergeEntities mocks in the entity combine specs with real repository doubles so tests verify primary data is preserved and duplicate attributes are merged
- assert that each service reassigns related publications or author links and prunes duplicate records after combining
- extend the publication combine spec to exercise aggregated funders, identifiers, and cleanup hooks

## Testing
- npm test -- --runInBand --runTestsByPath src/oa_category/oa-category.service.spec.ts src/pub_type/publication-type.service.spec.ts src/publisher/publisher.service.spec.ts src/contract/contract.service.spec.ts src/funder/funder.service.spec.ts src/institute/institute.service.spec.ts src/greater_entity/greater-entitiy.service.spec.ts src/publication/core/publication.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68fc917e21408330a44c4cde8c60d116